### PR TITLE
Validate gallery cache use case

### DIFF
--- a/NASAGallery/NASAGallery.xcodeproj/project.pbxproj
+++ b/NASAGallery/NASAGallery.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		925D36022B08037000FE12DA /* NASAGallery.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 925D35F92B08037000FE12DA /* NASAGallery.framework */; };
 		925D36122B08037A00FE12DA /* GalleryImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D36112B08037A00FE12DA /* GalleryImage.swift */; };
 		925D36142B0804A900FE12DA /* GalleryLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D36132B0804A900FE12DA /* GalleryLoader.swift */; };
+		9269EEB82BAE6C1500F68429 /* ValidateGalleryFromCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9269EEB72BAE6C1500F68429 /* ValidateGalleryFromCacheUseCaseTests.swift */; };
 		9282C93A2B1A932900D564DE /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9282C9392B1A932900D564DE /* SharedTestHelpers.swift */; };
 		9289F58F2B9939B600FBB279 /* CacheGalleryUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9289F58E2B9939B600FBB279 /* CacheGalleryUseCaseTests.swift */; };
 		92A2737E2B2A141600C37E9E /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A2737D2B2A141600C37E9E /* HTTPClient.swift */; };
@@ -61,6 +62,7 @@
 		925D36012B08037000FE12DA /* NASAGalleryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NASAGalleryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		925D36112B08037A00FE12DA /* GalleryImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryImage.swift; sourceTree = "<group>"; };
 		925D36132B0804A900FE12DA /* GalleryLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryLoader.swift; sourceTree = "<group>"; };
+		9269EEB72BAE6C1500F68429 /* ValidateGalleryFromCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateGalleryFromCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		9282C9392B1A932900D564DE /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
 		9289F58E2B9939B600FBB279 /* CacheGalleryUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheGalleryUseCaseTests.swift; sourceTree = "<group>"; };
 		92A2737D2B2A141600C37E9E /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
@@ -229,6 +231,7 @@
 				92EF7CD82BA4BC8200F19C34 /* Helpers */,
 				9289F58E2B9939B600FBB279 /* CacheGalleryUseCaseTests.swift */,
 				92DC023C2BA4842B00515BF5 /* LoadGalleryFromCacheUseCaseTests.swift */,
+				9269EEB72BAE6C1500F68429 /* ValidateGalleryFromCacheUseCaseTests.swift */,
 			);
 			path = "Gallery Cache";
 			sourceTree = "<group>";
@@ -453,6 +456,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				92EF7CDE2BA4BD4800F19C34 /* CacheHelpers.swift in Sources */,
+				9269EEB82BAE6C1500F68429 /* ValidateGalleryFromCacheUseCaseTests.swift in Sources */,
 				92032A7C2B213423008053C0 /* Fixtures.swift in Sources */,
 				92EF7CDD2BA4BD4300F19C34 /* GalleryStoreSpy.swift in Sources */,
 				92A2A4C72B0C23AE003F7B74 /* LoadGalleryFromRemoteUseCaseTests.swift in Sources */,

--- a/NASAGallery/NASAGallery/Gallery Cache/LocalGalleryLoader.swift
+++ b/NASAGallery/NASAGallery/Gallery Cache/LocalGalleryLoader.swift
@@ -29,7 +29,7 @@ public final class LocalGalleryLoader {
         do {
             let cache = try store.retrieve()
             
-            guard validate(cache.timestamp) else { 
+            guard validate(cache.timestamp) else {
                 try store.deleteCachedGallery()
                 return []
             }
@@ -47,6 +47,16 @@ public final class LocalGalleryLoader {
             return false
         }
         return Date() < maxCacheAge
+    }
+    
+    // Note: This is a prime example of a command function only! (CQS separation). It can produce side-effects (cache deletion)
+    public func validateCache() throws {
+        do {
+            let cache = try store.retrieve()
+        } catch {
+            try store.deleteCachedGallery()
+            throw error
+        }
     }
 }
 

--- a/NASAGallery/NASAGallery/Gallery Cache/LocalGalleryLoader.swift
+++ b/NASAGallery/NASAGallery/Gallery Cache/LocalGalleryLoader.swift
@@ -11,6 +11,8 @@ public final class LocalGalleryLoader {
     private let maxCacheAgeInDays: Int = 2
     private let calendar = Calendar(identifier: .gregorian)
     
+    // TODO: add private struct InvalidCache: Error {}
+
     private let store: GalleryStore
     
     public init(store: GalleryStore) {

--- a/NASAGallery/NASAGallery/Gallery Cache/LocalGalleryLoader.swift
+++ b/NASAGallery/NASAGallery/Gallery Cache/LocalGalleryLoader.swift
@@ -28,18 +28,11 @@ public final class LocalGalleryLoader {
     }
     
     public func load() throws -> [LocalGalleryImage] {
-        do {
-            let cache = try store.retrieve()
-            
-            guard validate(cache.timestamp) else {
-                try store.deleteCachedGallery()
-                return []
-            }
-            
-            return cache.gallery
-        } catch {
-            throw error
-        }
+        let cache = try store.retrieve()
+        
+        guard validate(cache.timestamp) else { return [] }
+        
+        return cache.gallery
     }
     
     // TODO: verify again Date() against currentDate() closure

--- a/NASAGallery/NASAGallery/Gallery Cache/LocalGalleryLoader.swift
+++ b/NASAGallery/NASAGallery/Gallery Cache/LocalGalleryLoader.swift
@@ -55,6 +55,10 @@ public final class LocalGalleryLoader {
     public func validateCache() throws {
         do {
             let cache = try store.retrieve()
+            
+            if !validate(cache.timestamp) {
+                try store.deleteCachedGallery()
+            }
         } catch {
             try store.deleteCachedGallery()
             throw error

--- a/NASAGallery/NASAGallery/Gallery Cache/LocalGalleryLoader.swift
+++ b/NASAGallery/NASAGallery/Gallery Cache/LocalGalleryLoader.swift
@@ -38,7 +38,6 @@ public final class LocalGalleryLoader {
             
             return cache.gallery
         } catch {
-            try store.deleteCachedGallery()
             throw error
         }
     }

--- a/NASAGallery/NASAGalleryTests/Gallery Cache/Helpers/CacheHelpers.swift
+++ b/NASAGallery/NASAGalleryTests/Gallery Cache/Helpers/CacheHelpers.swift
@@ -15,3 +15,9 @@ func uniqueLocalImages(title: String = "") -> (local: [LocalGalleryImage], image
     }
     return (local, images.model)
 }
+
+// Cache DSL, domain Language
+var cacheMaxAgeLimitTimestamp: Date {
+    let currentDate = Date()
+    return currentDate.adding(days: -2)
+}

--- a/NASAGallery/NASAGalleryTests/Gallery Cache/LoadGalleryFromCacheUseCaseTests.swift
+++ b/NASAGallery/NASAGalleryTests/Gallery Cache/LoadGalleryFromCacheUseCaseTests.swift
@@ -138,8 +138,8 @@ final class LoadGalleryFromCacheUseCaseTests: XCTestCase {
     
     func test_load_deletesCacheOnCacheExpiration() {
         let (sut, spy) = makeSUT()
-        let expiredCache = LocalCache(gallery: uniqueLocalImages().local, timestamp: cacheMaxAgeLimitTimestamp)
-        spy.stub(retrivalReturn: expiredCache)
+        let onExpirationCache = LocalCache(gallery: uniqueLocalImages().local, timestamp: cacheMaxAgeLimitTimestamp)
+        spy.stub(retrivalReturn: onExpirationCache)
         
         _ = try? sut.load()
         

--- a/NASAGallery/NASAGalleryTests/Gallery Cache/LoadGalleryFromCacheUseCaseTests.swift
+++ b/NASAGallery/NASAGalleryTests/Gallery Cache/LoadGalleryFromCacheUseCaseTests.swift
@@ -50,14 +50,7 @@ final class LoadGalleryFromCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(spy.receivedMessages, [.retrieve])
     }
     
-    func test_load_deletesCacheOnRetrievalError() {
-        let (sut, spy) = makeSUT()
-        spy.stub(retrivalError: AnyError(message: "Retrival Error"))
-        
-        _ = try? sut.load()
-        
-        XCTAssertEqual(spy.receivedMessages, [.retrieve, .delete])
-    }
+
     
     func test_load_doesNotDeleteCacheOnEmptyCache() {
         let (sut, spy) = makeSUT()
@@ -155,6 +148,17 @@ final class LoadGalleryFromCacheUseCaseTests: XCTestCase {
         _ = try? sut.load()
         
         XCTAssertEqual(spy.receivedMessages, [.retrieve, .delete])
+    }
+    
+    // MARK: - Side Effects
+    
+    func test_load_onRetrievalError_hasNoSideEffects() {
+        let (sut, spy) = makeSUT()
+        spy.stub(retrivalError: AnyError(message: "Retrival Error"))
+        
+        _ = try? sut.load()
+        
+        XCTAssertEqual(spy.receivedMessages, [.retrieve])
     }
 }
 

--- a/NASAGallery/NASAGalleryTests/Gallery Cache/LoadGalleryFromCacheUseCaseTests.swift
+++ b/NASAGallery/NASAGalleryTests/Gallery Cache/LoadGalleryFromCacheUseCaseTests.swift
@@ -78,7 +78,7 @@ final class LoadGalleryFromCacheUseCaseTests: XCTestCase {
         XCTAssertThrowsError(try sut.load())
     }
     
-    func test_load_onEmptyCache_failsWithNoImages() throws {
+    func test_load_onEmptyCache_deliversNoImages() throws {
         let (sut, spy) = makeSUT()
         let expectedCache = LocalCache(gallery: [], timestamp: Date())
         spy.stub(retrivalReturn: expectedCache)

--- a/NASAGallery/NASAGalleryTests/Gallery Cache/ValidateGalleryFromCacheUseCaseTests.swift
+++ b/NASAGallery/NASAGalleryTests/Gallery Cache/ValidateGalleryFromCacheUseCaseTests.swift
@@ -31,19 +31,32 @@ final class ValidateGalleryFromCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(spy.receivedMessages, [])
     }
     
-//    - `test_validateCache_doesNotDeleteCacheOnEmptyCache`
 //    - `test_validateCache_doesNotDeleteLessThanSevenDaysOldCache`
 //    - `test_validateCache_deletesSevenDaysOldCache`
 //    - `test_validateCache_deletesMoreThanSevenDaysOldCache`
 //    - `test_validateCache_doesNotDeleteInvalidCacheAfterSUTInstanceHasBeenDeallocated`
+    // Rename Load tests!
+    // And load function!
+    // PODE SER CONDITION_SIDEEFFECT!
 
-    func test_validateCache_onRetrievalError_succeedsToDeleteCache() {
+    func test_validateCache_onRetrievalError_deletesCache() {
         let (sut, spy) = makeSUT()
         spy.stub(retrivalError: AnyError(message: "Retrival Error"))
         
         _ = try? sut.validateCache()
         
         XCTAssertEqual(spy.receivedMessages, [.retrieve, .delete])
+    }
+    
+    func test_validateCache_onNonExpiredCache_doesNotDeleteCache() {
+        let (sut, spy) = makeSUT()
+        let lessThanMaxOldTimestamp = cacheMaxAgeLimitTimestamp.adding(seconds: 1)
+        let expectedCache = LocalCache(gallery: uniqueLocalImages().local, timestamp: lessThanMaxOldTimestamp)
+        spy.stub(retrivalReturn: expectedCache)
+        
+        _ = try? sut.validateCache()
+        
+        XCTAssertEqual(spy.receivedMessages, [.retrieve])
     }
 }
 

--- a/NASAGallery/NASAGalleryTests/Gallery Cache/ValidateGalleryFromCacheUseCaseTests.swift
+++ b/NASAGallery/NASAGalleryTests/Gallery Cache/ValidateGalleryFromCacheUseCaseTests.swift
@@ -31,7 +31,6 @@ final class ValidateGalleryFromCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(spy.receivedMessages, [])
     }
     
-//    - `test_validateCache_doesNotDeleteLessThanSevenDaysOldCache`
 //    - `test_validateCache_deletesSevenDaysOldCache`
 //    - `test_validateCache_deletesMoreThanSevenDaysOldCache`
 //    - `test_validateCache_doesNotDeleteInvalidCacheAfterSUTInstanceHasBeenDeallocated`
@@ -43,20 +42,30 @@ final class ValidateGalleryFromCacheUseCaseTests: XCTestCase {
         let (sut, spy) = makeSUT()
         spy.stub(retrivalError: AnyError(message: "Retrival Error"))
         
-        _ = try? sut.validateCache()
+        try? sut.validateCache()
         
         XCTAssertEqual(spy.receivedMessages, [.retrieve, .delete])
     }
     
-    func test_validateCache_onNonExpiredCache_doesNotDeleteCache() {
+    func test_validateCache_onNonExpiredCache_doesNotDeleteCache() throws {
         let (sut, spy) = makeSUT()
         let lessThanMaxOldTimestamp = cacheMaxAgeLimitTimestamp.adding(seconds: 1)
         let expectedCache = LocalCache(gallery: uniqueLocalImages().local, timestamp: lessThanMaxOldTimestamp)
         spy.stub(retrivalReturn: expectedCache)
         
-        _ = try? sut.validateCache()
+        try sut.validateCache()
         
         XCTAssertEqual(spy.receivedMessages, [.retrieve])
+    }
+    
+    func test_validadeCache_onCacheExpiration_deletesCache() throws {
+        let (sut, spy) = makeSUT()
+        let onExpirationCache = LocalCache(gallery: uniqueLocalImages().local, timestamp: cacheMaxAgeLimitTimestamp)
+        spy.stub(retrivalReturn: onExpirationCache)
+        
+        try sut.validateCache()
+        
+        XCTAssertEqual(spy.receivedMessages, [.retrieve, .delete])
     }
 }
 

--- a/NASAGallery/NASAGalleryTests/Gallery Cache/ValidateGalleryFromCacheUseCaseTests.swift
+++ b/NASAGallery/NASAGalleryTests/Gallery Cache/ValidateGalleryFromCacheUseCaseTests.swift
@@ -30,6 +30,21 @@ final class ValidateGalleryFromCacheUseCaseTests: XCTestCase {
         
         XCTAssertEqual(spy.receivedMessages, [])
     }
+    
+//    - `test_validateCache_doesNotDeleteCacheOnEmptyCache`
+//    - `test_validateCache_doesNotDeleteLessThanSevenDaysOldCache`
+//    - `test_validateCache_deletesSevenDaysOldCache`
+//    - `test_validateCache_deletesMoreThanSevenDaysOldCache`
+//    - `test_validateCache_doesNotDeleteInvalidCacheAfterSUTInstanceHasBeenDeallocated`
+
+    func test_validateCache_onRetrievalError_succeedsToDeleteCache() {
+        let (sut, spy) = makeSUT()
+        spy.stub(retrivalError: AnyError(message: "Retrival Error"))
+        
+        _ = try? sut.validateCache()
+        
+        XCTAssertEqual(spy.receivedMessages, [.retrieve, .delete])
+    }
 }
 
 // MARK: - Helpers

--- a/NASAGallery/NASAGalleryTests/Gallery Cache/ValidateGalleryFromCacheUseCaseTests.swift
+++ b/NASAGallery/NASAGalleryTests/Gallery Cache/ValidateGalleryFromCacheUseCaseTests.swift
@@ -31,9 +31,6 @@ final class ValidateGalleryFromCacheUseCaseTests: XCTestCase {
         XCTAssertEqual(spy.receivedMessages, [])
     }
     
-//    - `test_validateCache_deletesSevenDaysOldCache`
-//    - `test_validateCache_deletesMoreThanSevenDaysOldCache`
-//    - `test_validateCache_doesNotDeleteInvalidCacheAfterSUTInstanceHasBeenDeallocated`
     // Rename Load tests!
     // And load function!
     // PODE SER CONDITION_SIDEEFFECT!
@@ -62,6 +59,17 @@ final class ValidateGalleryFromCacheUseCaseTests: XCTestCase {
         let (sut, spy) = makeSUT()
         let onExpirationCache = LocalCache(gallery: uniqueLocalImages().local, timestamp: cacheMaxAgeLimitTimestamp)
         spy.stub(retrivalReturn: onExpirationCache)
+        
+        try sut.validateCache()
+        
+        XCTAssertEqual(spy.receivedMessages, [.retrieve, .delete])
+    }
+    
+    func test_validateCache_onExpiredCache_deletesCache() throws {
+        let (sut, spy) = makeSUT()
+        let moreThanMaxOldTimestamp = cacheMaxAgeLimitTimestamp.adding(seconds: -1)
+        let expiredCache = LocalCache(gallery: uniqueLocalImages().local, timestamp: moreThanMaxOldTimestamp)
+        spy.stub(retrivalReturn: expiredCache)
         
         try sut.validateCache()
         

--- a/NASAGallery/NASAGalleryTests/Gallery Cache/ValidateGalleryFromCacheUseCaseTests.swift
+++ b/NASAGallery/NASAGalleryTests/Gallery Cache/ValidateGalleryFromCacheUseCaseTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import NASAGallery
 
 /* Author Notes on ValidateGalleryFromCacheUseCaseTests
  
@@ -24,7 +25,23 @@ import XCTest
 */
 final class ValidateGalleryFromCacheUseCaseTests: XCTestCase {
 
-//    func test() {
-//        XCTFail("Initial failing test.")
-//    }
+    func test_init_doesNotMessageStoreUponCreation() {
+        let (_, spy) = makeSUT()
+        
+        XCTAssertEqual(spy.receivedMessages, [])
+    }
 }
+
+// MARK: - Helpers
+private extension ValidateGalleryFromCacheUseCaseTests {
+    func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: LocalGalleryLoader, store: GalleryStoreSpy) {
+        let store = GalleryStoreSpy()
+        let sut = LocalGalleryLoader(store: store)
+        
+        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeaks(store, file: file, line: line)
+        
+        return (sut, store)
+    }
+}
+

--- a/NASAGallery/NASAGalleryTests/Gallery Cache/ValidateGalleryFromCacheUseCaseTests.swift
+++ b/NASAGallery/NASAGalleryTests/Gallery Cache/ValidateGalleryFromCacheUseCaseTests.swift
@@ -1,0 +1,30 @@
+//
+//  ValidateGalleryFromCacheUseCaseTests.swift
+//  NASAGalleryTests
+//
+//  Created by Ivo on 22/03/24.
+//
+
+import XCTest
+
+/* Author Notes on ValidateGalleryFromCacheUseCaseTests
+ 
+ ### 3. Validate Gallery Cache Use Case
+
+ #### Primary course:
+ 1. Execute "Validate Cached APOD Gallery" command.
+ 2. System retrieves gallery data from cache.
+ 3. System validates cache age againts maximum age: verify if it is less than 2 days old.
+
+ #### Retrieval error course (sad path):
+ 1. System deletes cache.
+
+ #### Expired cache course (sad path):
+ 1. System deletes cache.
+*/
+final class ValidateGalleryFromCacheUseCaseTests: XCTestCase {
+
+//    func test() {
+//        XCTFail("Initial failing test.")
+//    }
+}

--- a/NASAGallery/NASAGalleryTests/Gallery Cache/ValidateGalleryFromCacheUseCaseTests.swift
+++ b/NASAGallery/NASAGalleryTests/Gallery Cache/ValidateGalleryFromCacheUseCaseTests.swift
@@ -30,10 +30,6 @@ final class ValidateGalleryFromCacheUseCaseTests: XCTestCase {
         
         XCTAssertEqual(spy.receivedMessages, [])
     }
-    
-    // Rename Load tests!
-    // And load function!
-    // PODE SER CONDITION_SIDEEFFECT!
 
     func test_validateCache_onRetrievalError_deletesCache() {
         let (sut, spy) = makeSUT()

--- a/README.md
+++ b/README.md
@@ -184,12 +184,12 @@ GET *url* (TBD)
 ### Test Name Convention
 
 #### Tests with Condition
-```test_[MethodName]_[ConditionOrScenario]_[Success-Failure-ExpectedOutcome]```   
+```test_[MethodName]_[ConditionOrScenario]_[Success/Failure-SideEffect]```   
 * test_getFromURL_withDataOnHTTPURLResponse_succeeds
 * test_load_on200HTTPResponseWithInvalidJSON_failsWithInvalidDataError
+* test_validateCache_onExpiredCache_deletesCache
 
 #### Testing simple outcome
 ```test_[Functionality]_[BehaviorOrOutcome]```
 * test_apiEndToEndTests_matchesFixedTestData
 * test_init_doesNotRequestDataFromURL
-* test_load_deletesCacheOnRetrievalError 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then the app should display an error message.
 
 ## Use Cases
 
-### Load APOD Gallery from Remote Use Case
+### 1. Load APOD Gallery from Remote Use Case
 
 #### Data:
 - APOD API URL
@@ -73,27 +73,37 @@ Then the app should display an error message.
 #### No connectivity – error course (sad path):
 1. System delivers connectivity error.
 
-### Load APOD Gallery from Cache Use Case 
+### 2. Load APOD Gallery from Cache Use Case 
 
 #### Primary course:
 1. Execute "Retrieve Cached APOD Gallery" command.
 2. System retrieves APOD Gallery data from cache.
-3. System validates cache age againts maximum age: verify if it is less than 2 days old.
 4. System creates APOD Gallery from valid cached data.
 5. System delivers APOD Gallery.
 
 #### Retrieval error course (sad path):
-1. System deletes cache.
-2. System delivers error.
+1. System delivers error.
 
 #### Expired cache course (sad path): 
-1. System deletes cache.
-2. System delivers no gallery.
+1. System delivers no gallery.
 
 #### Empty cache course (sad path): 
 1. System delivers no APOD gallery.
 
-### Cache APOD Use Case
+### 3. Validate Gallery Cache Use Case
+
+#### Primary course:
+1. Execute "Validate Cached APOD Gallery" command.
+2. System retrieves gallery data from cache.
+3. System validates cache age againts maximum age: verify if it is less than 2 days old.
+
+#### Retrieval error course (sad path):
+1. System deletes cache.
+
+#### Expired cache course (sad path): 
+1. System deletes cache.
+
+### 4. Cache APOD Use Case
 
 #### Data:
 - APOD items


### PR DESCRIPTION
 ### 3. Validate Gallery Cache Use Case

 #### Primary course:
 1. Execute "Validate Cached APOD Gallery" command.
 2. System retrieves gallery data from cache.
 3. System validates cache age againts maximum age: verify if it is less than 2 days old.

 #### Retrieval error course (sad path):
 1. System deletes cache.

 #### Expired cache course (sad path):
 1. System deletes cache.